### PR TITLE
Improve formatting of Slack messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "node-fetch": "^2.6.1"
       },
       "devDependencies": {
-        "@types/eslint": "^7.2.4",
         "eslint": "^7.12.1",
         "eslint-config-ackama": "^2.0.1",
         "eslint-plugin-eslint-comments": "^3.2.0",
@@ -27,8 +26,7 @@
         "jest": "^26.6.3",
         "prettier": "^2.1.2",
         "prettier-config-ackama": "^0.1.2",
-        "serverless-dotenv-plugin": "^3.1.0",
-        "typescript": "^4.8.3"
+        "serverless-dotenv-plugin": "^3.1.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -978,22 +976,6 @@
       "dependencies": {
         "@babel/types": "^7.3.0"
       }
-    },
-    "node_modules/@types/eslint": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.4.tgz",
-      "integrity": "sha512-YCY4kzHMsHoyKspQH+nwSe+70Kep7Vjt2X+dZe5Vs2vkRudqtoFoUIv1RlJmZB8Hbp7McneupoZij4PadxsK5Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/estree": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
-      "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
-      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.4",
@@ -7666,6 +7648,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8993,22 +8976,6 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
-    },
-    "@types/eslint": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.4.tgz",
-      "integrity": "sha512-YCY4kzHMsHoyKspQH+nwSe+70Kep7Vjt2X+dZe5Vs2vkRudqtoFoUIv1RlJmZB8Hbp7McneupoZij4PadxsK5Q==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "@types/estree": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
-      "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
-      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.4",
@@ -14200,7 +14167,8 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "handler.js",
   "scripts": {
     "lint": "eslint . --ext js,jsx,ts,tsx",
-    "deploy-uat": "serverless deploy --stage=uat",
+    "deploy-staging": "serverless deploy --stage=staging",
     "deploy-prod": "serverless deploy --stage=prod",
     "coverage": "jest --silent --colors --coverage",
     "lint-fix": "eslint . --ext js,jsx,ts,tsx --fix",
@@ -27,8 +27,6 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "typescript": "^4.8.3",
-    "@types/eslint": "^7.2.4",
     "eslint": "^7.12.1",
     "eslint-config-ackama": "^2.0.1",
     "eslint-plugin-eslint-comments": "^3.2.0",

--- a/src/dateRange.js
+++ b/src/dateRange.js
@@ -19,3 +19,7 @@ module.exports.utcDayRange = (on = new Date()) => {
     dateFns.endOfDay(on, dayRangeOpts)
   ];
 };
+
+module.exports.utcMonthRange = (on = new Date()) => {
+  return [dateFns.startOfMonth(on), dateFns.endOfMonth(on)];
+};

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -6,7 +6,7 @@ class Notifier {
       throw new Error('Missing SLACK_WEBHOOK_URL from environment');
     }
     this.slackWebhook = new IncomingWebhook(url);
-    this.outputLinesBuffer = [];
+    this.blocksBuffer = [];
   }
 
   /**
@@ -14,23 +14,91 @@ class Notifier {
    * we have a record of it in case something happens which prevents the send.
    *
    * @param message The line to store in the buffer
+   * @param style The formatting style to use for the given block
    */
-  bufferMessage(message) {
-    console.log(message);
-    this.outputLinesBuffer.push(message);
+  bufferMessage(message, style) {
+    let block = {};
+
+    console.log(message, { style });
+
+    // The Slack docs are pretty crap about rich_text but some info is in
+    // https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less
+    switch (style) {
+      case 'bullet':
+        block = {
+          type: 'rich_text',
+          elements: [
+            {
+              type: 'rich_text_list',
+              style: 'bullet',
+              elements: [
+                {
+                  type: 'rich_text_section',
+                  elements: [
+                    {
+                      type: 'text', // Slack doesn't allow Markdown in bullet lists
+                      text: message
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        };
+        break;
+      case 'header':
+        block = {
+          type: 'header',
+          text: {
+            type: 'plain_text',
+            text: message,
+            emoji: true
+          }
+        };
+        break;
+      case 'section':
+        block = {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: message
+          }
+        };
+        break;
+
+      default:
+        console.error(`Unrecognised style: ${style}`);
+        block = {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `:warning: Unrecognised style ${style}`
+          }
+        };
+        break;
+    }
+
+    this.blocksBuffer.push(block);
   }
 
   /**
    * Send buffered messages and immediately empty the buffer
    */
   async sendBufferedMessages() {
-    const output = this.outputLinesBuffer.join('\n');
-
     try {
-      await this.slackWebhook.send({ text: output });
+      const payload = { blocks: this.blocksBuffer };
+
+      // Debugging Slack formatting is tricky but you can paste the JSON into
+      // the Slack Block builder and it will give you much better error messages:
+      //
+      //   https://app.slack.com/block-kit-builder/
+      //
+      // console.log(JSON.stringify(payload));
+
+      await this.slackWebhook.send(payload);
 
       // empty the buffer now that we have successfully sent its contents to Slack
-      this.outputLinesBuffer = [];
+      this.blocksBuffer = [];
     } catch (e) {
       console.error('Error sending to slack webhook:', e);
 


### PR DESCRIPTION
* Improve formatting of Slack messages
* Remove typescript runtime dependency which is no longer needed
* Add `utcMonthRange` method which is convenient for local dev (when you need to see a large range of results)
