### PR TITLE
Fix formatting issue in weekly report

### DIFF
--- a/src/leaveReminder.ts
+++ b/src/leaveReminder.ts
@@ -35,7 +35,7 @@ const formatForWeeklyReport = ({ user, days }: Leave, withDate = true) => {
     .map(
       ({ Date: dateStr, Hours: hours }) =>
         `${
-          withDate ? toDateTime(new Date(dateStr)).toFormat('EEE do') : ''
+          withDate ? toDateTime(new Date(dateStr)).toFormat('EEE d LLL') : ''
         } (${formatHours(hours)})`
     )
     .filter(entry => entry.length)


### PR DESCRIPTION
Luxon does not support ordinal date formating (1st, 2nd, 3rd etc.) because it is not supported by the underlying `Intl.DateTimeFormat`.
There is an open issue: https://github.com/moment/luxon/issues/118

This change formats dates in weekly now reports as `Fri 13 Jan (3.8 hrs)`